### PR TITLE
add --ignore FILE option

### DIFF
--- a/linkenv/linkenv.py
+++ b/linkenv/linkenv.py
@@ -85,13 +85,13 @@ def main(argv = sys.argv):
 	parser.add_option('-c', '--copy', dest='copy', action='store_true', default=False,
 										help='Copy packages instead of symlinking'
 									 )
-	parser.add_option('-i', '--ignore', dest='ignore', action='store', metavar='FILE',
+	parser.add_option('-i', '--ignore-file', dest='ignorefile', action='store', metavar='FILE',
 										help='FILE that lists packages to ignore'
 									 )
 	(options, args) = parser.parse_args()
 
 	copy = options.copy
-	ignorefile = options.ignore
+	ignorefile = options.ignorefile
 
 	if len(args) != 2:
 		parser.error('source and target directories must be specified')


### PR DESCRIPTION
Allows you to specify a file listing packages to ignore. 

Very basic: does not know anything about dependencies, so you have to explicitly list all the packages you don't want, including their dependencies. It's kind of a pain, but it works, and I would assume this would be a very common need (as indicated by @pwalsh 's fork too).

Also changed it to parse argv with OptionParser (easier when you have >1 option)
